### PR TITLE
Prometheus and Grafana

### DIFF
--- a/helm/featurehub/Chart.lock
+++ b/helm/featurehub/Chart.lock
@@ -1,9 +1,15 @@
 dependencies:
+- name: grafana
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.9.8
+- name: kube-prometheus
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.0.9
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.0.5
 - name: nats
   repository: https://nats-io.github.io/k8s/helm/charts/
   version: 0.13.1
-digest: sha256:ba62bc3579a52f4b375a9ccbacef334129259516b2ff34de591347663af5e610
-generated: "2022-02-28T15:29:12.110834078Z"
+digest: sha256:40f9e9f7e7767d32b337aed99f5bead1c97c3033e26180e947de63527e419e1f
+generated: "2022-07-03T09:34:29.767538+12:00"

--- a/helm/featurehub/Chart.yaml
+++ b/helm/featurehub/Chart.yaml
@@ -6,6 +6,14 @@ version: 3.0.4
 icon: https://feature-hub.io/img/png/favicon.png
 appVersion: "1.5.8"
 dependencies:
+  - name: grafana
+    version: 7.9.8
+    repository: https://charts.bitnami.com/bitnami
+    condition: grafana.enabled
+  - name: kube-prometheus
+    version: 8.0.9
+    repository: https://charts.bitnami.com/bitnami
+    condition: kube-prometheus.enabled
   - name: postgresql
     version: 11.0.5
     repository: https://charts.bitnami.com/bitnami

--- a/helm/featurehub/values.yaml
+++ b/helm/featurehub/values.yaml
@@ -159,7 +159,7 @@ managementRepository:
   prometheus:
     # -- Whether to enable or disable prometheus metrics endpoints, and serviceMonitor
     # If enabled, metrics are exposed on port 8701, on /metrics endpoint
-    enabled: false
+    enabled: true
     # -- Labels for the Prometheus Operator to handle the serviceMonitor
     labels: {}
 
@@ -313,7 +313,7 @@ edge:
   prometheus:
     # -- Whether to enable or disable prometheus metrics endpoints, and serviceMonitor
     # If enabled, metrics are exposed on port 8701, on /metrics endpoint
-    enabled: false
+    enabled: true
     # -- Labels for the Prometheus Operator to handle the serviceMonitor
     labels: {}
 
@@ -437,7 +437,7 @@ dacha:
   prometheus:
     # -- Whether to enable or disable prometheus metrics endpoints, and serviceMonitor
     # If enabled, metrics are exposed on port 8701, on /metrics endpoint
-    enabled: false
+    enabled: true
     # -- Labels for the Prometheus Operator to handle the serviceMonitor
     labels: {}
 
@@ -532,3 +532,35 @@ postgresql:
           CREATE DATABASE featurehub;
           GRANT ALL PRIVILEGES ON DATABASE featurehub TO featurehub;
 
+kube-prometheus:
+  enabled: true
+  blackboxExporter:
+    enabled: false
+  rbac:
+    pspEnabled: false
+  kubeProxy:
+    enabled: false
+  coreDns:
+    enabled: false
+  kubeScheduler:
+    enabled: false
+  kubeControllerManager:
+    enabled: false
+  kubeApiServer:
+    enabled: false
+  kubelet:
+    enabled: false
+  exporters:
+    kube-state-metrics:
+      enabled: false
+    node-exporter:
+      enabled: false
+
+grafana:
+  enabled: true
+  metrics:
+    enabled: true
+  admin:
+    password: featurehub
+  persistence:
+    size: 512Mi


### PR DESCRIPTION
This is designed to allow these two services to be in
the cluster to allow iteration on supporting useful Grafana
style dashboards for FeatureHub.